### PR TITLE
Link components to selectors

### DIFF
--- a/docs/components-selectors-mapping.md
+++ b/docs/components-selectors-mapping.md
@@ -1,8 +1,8 @@
 | Componente | Selector CSS | Sección UI-Selectors | Doc Componente |
 |------------|--------------|---------------------|----------------|
-| CarouselCollapse (`src/components/CarouselCollapse.tsx`) | `.swiper-wrapper` y `.swiper-slide` | [Estructura de Swiper – `.swiper-wrapper` y `.swiper-slide`](docs/ui-selectors.md#estructura-de-swiper-swiper-wrapper-y-swiper-slide) | [docs/src-components.md#carouselcollapse](docs/src-components.md#carouselcollapse) |
-| ContentStripe (`src/components/ContentStripe.tsx`) | `.software__services` | [Servicios de software – `.software__services`](docs/ui-selectors.md#servicios-de-software-software__services) | [docs/src-components.md#contentstripe](docs/src-components.md#contentstripe) |
-| Footer (`src/components/Footer.tsx`) | `footer` | [Pie de página – `footer`](docs/ui-selectors.md#pie-de-pagina-footer) | [docs/src-components.md#footer](docs/src-components.md#footer) |
-| Header (`src/components/Header.tsx`) | `nav.header.navbar` | [Header – `nav.header.navbar`](docs/ui-selectors.md#header-navheadernavbar) | [docs/src-components.md#header](docs/src-components.md#header) |
-| MainBanner (`src/components/MainBanner.tsx`) | `.main__slider` | [Banner principal – `.main__slider`](docs/ui-selectors.md#banner-principal-main__slider) | [docs/src-components.md#mainbanner](docs/src-components.md#mainbanner) |
+| CarouselCollapse (`src/components/CarouselCollapse.tsx`) | `.swiper-wrapper` y `.swiper-slide` | [Estructura de Swiper – `.swiper-wrapper` y `.swiper-slide`](ui-selectors.md#estructura-de-swiper-swiper-wrapper-y-swiper-slide) | [src-components.md#carouselcollapse](src-components.md#carouselcollapse) |
+| ContentStripe (`src/components/ContentStripe.tsx`) | `.software__services` | [Servicios de software – `.software__services`](ui-selectors.md#servicios-de-software-software__services) | [src-components.md#contentstripe](src-components.md#contentstripe) |
+| Footer (`src/components/Footer.tsx`) | `footer` | [Pie de página – `footer`](ui-selectors.md#pie-de-pagina-footer) | [src-components.md#footer](src-components.md#footer) |
+| Header (`src/components/Header.tsx`) | `nav.header.navbar` | [Header – `nav.header.navbar`](ui-selectors.md#header-navheadernavbar) | [src-components.md#header](src-components.md#header) |
+| MainBanner (`src/components/MainBanner.tsx`) | `.main__slider` | [Banner principal – `.main__slider`](ui-selectors.md#banner-principal-main__slider) | [src-components.md#mainbanner](src-components.md#mainbanner) |
 

--- a/docs/src-components.md
+++ b/docs/src-components.md
@@ -3,8 +3,8 @@
 Esta sección documenta los componentes de alto nivel (excluyendo `shared`) que componen la interfaz. Se ordenan por archivo y se indican props, estado, relación con el layout y notas de estilos.
 
 ## CarouselCollapse
-- **Selector**: `.swiper-wrapper` y `.swiper-slide`  
-  *Ver `docs/ui-selectors.md` sección "Estructura de Swiper – `.swiper-wrapper` y `.swiper-slide`" para detalles de DOM y comportamiento.*
+- **Selector**: `.swiper-wrapper` y `.swiper-slide`
+  *Ver `ui-selectors.md` sección "Estructura de Swiper – `.swiper-wrapper` y `.swiper-slide`" para detalles de DOM y comportamiento.*
 - **Ruta:** `src/components/CarouselCollapse.tsx` y estilos en `src/styles/components/_carusel__collapse.scss`.
 - **Relación con la UI:** carrusel que muestra tarjetas con un detalle colapsable; suele ubicarse en secciones informativas como "qué resolvemos".
 - **Props:**
@@ -18,8 +18,8 @@ Esta sección documenta los componentes de alto nivel (excluyendo `shared`) que 
 - **Estilos y breakpoints:** el SCSS define clases como `.what__solve` y ajusta la altura del carrusel. Se utilizan `breakpoints` de Swiper y reglas `@media` para definir cuántas tarjetas se ven según el ancho de pantalla.
 
 ## ContentStripe
-- **Selector**: `.software__services`  
-  *Ver `docs/ui-selectors.md` sección "Servicios de software – `.software__services`" para detalles de DOM y comportamiento.*
+- **Selector**: `.software__services`
+  *Ver `ui-selectors.md` sección "Servicios de software – `.software__services`" para detalles de DOM y comportamiento.*
 - **Ruta:** `src/components/ContentStripe.tsx` con estilos en `src/styles/components/_content__stripe.scss`.
 - **Relación con la UI:** franja de contenido con imagen y texto que puede invertirse (`imageRight`). Aparece en distintas secciones explicativas.
 - **Props:**
@@ -39,8 +39,8 @@ Esta sección documenta los componentes de alto nivel (excluyendo `shared`) que 
 - **Estilos y responsividad:** la hoja SCSS ajusta la posición de la imagen con `@media (max-width:768px)` para que se coloque primero en pantallas pequeñas (`order` de Bootstrap).
 
 ## Footer
-- **Selector**: `footer`  
-  *Ver `docs/ui-selectors.md` sección "Pie de página – `footer`" para detalles de DOM y comportamiento.*
+- **Selector**: `footer`
+  *Ver `ui-selectors.md` sección "Pie de página – `footer`" para detalles de DOM y comportamiento.*
 - **Ruta:** `src/components/Footer.tsx` con reglas en `src/styles/components/_footer.scss`.
 - **Relación con la UI:** pie de página que contiene el formulario de contacto y enlaces.
 - **Props:** no recibe props.
@@ -49,8 +49,8 @@ Esta sección documenta los componentes de alto nivel (excluyendo `shared`) que 
 - **Estilos y breakpoints:** el SCSS define la imagen de fondo y espacios internos (`padding`). Incluye reglas `@media` para reducir el `padding` en 992px y 768px.
 
 ## Header
-- **Selector**: `nav.header.navbar`  
-  *Ver `docs/ui-selectors.md` sección "Header – `nav.header.navbar`" para detalles de DOM y comportamiento.*
+- **Selector**: `nav.header.navbar`
+  *Ver `ui-selectors.md` sección "Header – `nav.header.navbar`" para detalles de DOM y comportamiento.*
 - **Ruta:** `src/components/Header.tsx` con estilos en `src/styles/components/_header.scss`.
 - **Relación con la UI:** barra de navegación fija en la parte superior.
 - **Props:** no tiene props.
@@ -59,8 +59,8 @@ Esta sección documenta los componentes de alto nivel (excluyendo `shared`) que 
 - **Estilos y responsividad:** el SCSS aplica `padding` a la marca y cambia colores cuando la clase `solid-nav` está presente. Con `@media (max-width:991px)` se aplica un fondo blanco al abrir el menú colapsable.
 
 ## MainBanner
-- **Selector**: `.main__slider`  
-  *Ver `docs/ui-selectors.md` sección "Banner principal – `.main__slider`" para detalles de DOM y comportamiento.*
+- **Selector**: `.main__slider`
+  *Ver `ui-selectors.md` sección "Banner principal – `.main__slider`" para detalles de DOM y comportamiento.*
 - **Ruta:** `src/components/MainBanner.tsx` y estilos en `src/styles/components/_main__banner.scss`.
 - **Relación con la UI:** banner principal de cada página; admite un botón opcional para volver a la home.
 - **Props:**


### PR DESCRIPTION
## Summary
- cross reference components with DOM selectors
- map components to selectors in a new table

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685b00c72db08324b0e8f949815a9017