### PR TITLE
Fix ngrok blocked host

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Sitio web corporativo construido como SPA con **React** y **TypeScript**. Muestr
    npm run dev
    ```
    El servidor se inicia en `http://localhost:8080`.
+   Si usas **ngrok** para exponer el proyecto, agrega el dominio generado en
+   `server.allowedHosts` dentro de `vite.config.ts` para evitar el mensaje
+   "Blocked request".
 4. Build de producción:
    ```bash
    npm run build

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Sitio web corporativo construido como SPA con **React** y **TypeScript**. Muestr
    npm run dev
    ```
    El servidor se inicia en `http://localhost:8080`.
-   Si usas **ngrok** para exponer el proyecto, agrega el dominio generado en
-   `server.allowedHosts` dentro de `vite.config.ts` para evitar el mensaje
-   "Blocked request".
+    Si usas **ngrok** para exponer el proyecto, permite todos los subdominios
+    de `ngrok-free.app` agregando `/\.ngrok-free\.app$/` a
+    `server.allowedHosts` dentro de `vite.config.ts`. Esto evita el mensaje
+    "Blocked request".
 4. Build de producción:
    ```bash
    npm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,8 @@ export default defineConfig({
     host: true,
     port: 8080,
     strictPort: true,
-    // Explicitly allow ngrok domain for external access
-    allowedHosts: [
-      "d59f-2800-810-5f6-429-dc71-6518-499-4cb7.ngrok-free.app",
-    ],
+    // Allow any ngrok domain (e.g. *.ngrok-free.app) for external access
+    allowedHosts: [/\.ngrok-free\.app$/],
   },
   logLevel: "info",
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     host: true,
     port: 8080,
     strictPort: true,
+    // Explicitly allow ngrok domain for external access
+    allowedHosts: [
+      "d59f-2800-810-5f6-429-dc71-6518-499-4cb7.ngrok-free.app",
+    ],
   },
   logLevel: "info",
 });


### PR DESCRIPTION
## Summary
- allow ngrok domain via `server.allowedHosts`
- document how to configure ngrok in development

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm run build` *(fails to compile TypeScript due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685c41178ba883248162c13104b220b8