### PR TITLE
Update AGENTS guide with docs reindex rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 section_id: "AGENTS-00"
 title: "Guía de Agentes"
-version: "1.0"
+version: "1.1"
 date: "2025-06-30"
 
 related_sections:
@@ -33,6 +33,7 @@ Este archivo define los agentes que colaboran en el mantenimiento y ampliación 
 ### Code Agent
 - **Objetivo:** Refactorizar y actualizar contenido, estructura de componentes y CSS conforme a la guía de estilo y a los identificadores de sección.
 - **Recursos a leer:** `docs/STYLEGUIDE.md`, `docs/summary-index.json`, `README.md`.
+- **Regla compartida:** Al actualizar cualquier archivo dentro de `docs/`, se debe reindexar toda la documentación siguiendo las reglas de `docs/STYLEGUIDE.md`, y todos los documentos que lo requieran deben incluir el Front Matter YAML especificado en la guía de estilo.
 
 ### Design Agent *(opcional)*
 - **Objetivo:** Aplicar cambios de diseño ajustando SCSS/Bootstrap/MUI según maquetas o directrices. Generar *snippets* de estilo y clases reutilizables.
@@ -45,6 +46,7 @@ Este archivo define los agentes que colaboran en el mantenimiento y ampliación 
 ### Doc Agent
 - **Objetivo:** Actualizar `docs/components-selectors-mapping.md`, `docs/src-components.md` y otros archivos de documentación al modificar o mover componentes.
 - **Recursos a leer:** Todos los documentos en `docs/` y `README.md`.
+- **Regla compartida:** Al actualizar cualquier archivo dentro de `docs/`, se debe reindexar toda la documentación siguiendo las reglas de `docs/STYLEGUIDE.md`, y todos los documentos que lo requieran deben incluir el Front Matter YAML especificado en la guía de estilo.
 
 ## Plantilla de Front Matter YAML
 Se recomienda incluir el siguiente bloque al inicio de cada archivo `docs/*.md` para mantener uniformidad.


### PR DESCRIPTION
## Summary
- bump AGENTS guide version to 1.1
- add a shared rule about reindexing docs when any file in `docs/` changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6862a210806083248587bae6c1c262f6