### PR TITLE
Update entrypoint router doc

### DIFF
--- a/docs/entrypoint-and-router.md
+++ b/docs/entrypoint-and-router.md
@@ -1,4 +1,42 @@
-# Arranque y enrutado de la aplicación
+---
+section_id: "ENTRY-ROUTER-03"
+title: "Arranque y Enrutado"
+version: "1.0"
+date: "2025-07-01"
+related_sections:
+  - "files-and-folders.md"
+  - "root-and-global-configuration.md"
+  - "summary-index.json"
+enforce:
+  - styleguide: "STYLEGUIDE.md"
+  - summary_index: "summary-index.json"
+agents:
+  - Code Agent
+  - Test Agent
+  - Doc Agent
+use_all_sections: false
+---
+# Arranque y Enrutado
+
+Esquema JSON de rutas
+
+```json
+[
+  { "path": "/",                 "component": "Home",             "layout": "Layout" },
+  { "path": "/home",             "component": "Home",             "layout": "Layout" },
+  { "path": "/remote-assistant", "component": "RemoteAssistant",  "layout": "Layout" },
+  // …otras rutas
+]
+```
+
+```mermaid
+graph TD
+  Browser -->|visita /| Layout
+  Layout --> Home
+  Layout --> RemoteAssistant
+  Layout --> SmartRutines
+  // …otras transiciones
+```
 
 Este documento describe cómo se inicializa la SPA de Sowtic y la forma en que se configuran sus rutas principales.
 
@@ -36,4 +74,25 @@ Este documento describe cómo se inicializa la SPA de Sowtic y la forma en que s
 - **Uso:** se importa en `main.tsx` de modo que Vite lo procese y lo inserte en la aplicación.
 
 En conjunto, `main.tsx` arranca la aplicación cargando `index.scss` y renderizando `Router`, el cual gestiona las rutas mediante `createBrowserRouter`. Esto garantiza que todas las páginas se sirvan dentro del layout principal y que los estilos globales estén disponibles desde el inicio.
+
+[Code Agent]
+"Usa este JSON y el STYLEGUIDE.md para actualizar src/router.tsx añadiendo la ruta /contact que renderice ContactPage bajo <Layout>."
+
+## Criterios de Aceptación
+1. Todas las rutas aparecen en `src/router.tsx` y coinciden con el JSON de definición.
+2. Cada página se envuelve correctamente en `<Layout>` (Header + Footer).
+3. El future flag `v7_startTransition` permanece activo.
+4. Tests automatizados validan que cada ruta monta el componente correcto.
+
+### Tests de enrutado automatizados
+```yaml
+routes:
+  - path: "/"
+    expected: "Home"
+  - path: "/smart-rutines"
+    expected: "SmartRutines"
+  # …otras rutas
+```
+
+"Genera tests en Jest + React Testing Library que iteren este archivo YAML y verifiquen que cada ruta monta el componente correcto."
 

--- a/docs/summary-index.json
+++ b/docs/summary-index.json
@@ -1,6 +1,6 @@
 [
   { "id": "SUMMARY-01", "title": "Mapa de Componentes y Selectores", "file": "components-selectors-mapping.md" },
-  { "id": "SUMMARY-02", "title": "Arranque y Enrutado de la Aplicación", "file": "entrypoint-and-router.md" },
+  { "id": "SUMMARY-02", "title": "Arranque y Enrutado", "file": "entrypoint-and-router.md" },
   { "id": "SUMMARY-03", "title": "Archivos y Carpetas", "file": "files-and-folders.md" },
   { "id": "SUMMARY-04", "title": "Archivos estáticos en public", "file": "public.md" },
   { "id": "SUMMARY-05", "title": "Configuración raíz del proyecto", "file": "root-and-global-configuration.md" },


### PR DESCRIPTION
## Summary
- enrich entrypoint and router documentation with YAML front matter
- add routes JSON, mermaid graph and new agent prompts
- document acceptance criteria and automated routing tests
- update summary-index with new doc title

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6862aacfa2c08324b819f75600af0083