### PR TITLE
Update doc for in-memory services

### DIFF
--- a/docs/src-services-databaseInMemory.md
+++ b/docs/src-services-databaseInMemory.md
@@ -1,52 +1,78 @@
-# Datos simulados en `src/services/databaseInMemory/`
+---
+section_id: "DB-IMEM-11"
+title: "Servicios InMemory de Datos"
+version: "1.0"
+date: "2025-07-01"
+related_sections:
+  - "src-services-interface.md"
+  - "src-services.md"
+  - "summary-index.json"
+enforce:
+  - styleguide: "STYLEGUIDE.md"
+  - summary_index: "summary-index.json"
+agents:
+  - Code Agent
+  - Test Agent
+  - Doc Agent
+---
 
-Esta carpeta contiene arreglos estáticos que sirven como "base de datos" en memoria. Los servicios (`bannerService.ts`, `cardService.ts` y `stripeService.ts`) consumen esta información para suministrar contenido a las páginas.
+```json
+[
+  {
+    "name": "banner.ts",
+    "path": "src/services/databaseInMemory/banner.ts",
+    "export": "BANNERS: BannerInterface[]",
+    "consumers": ["bannerService.ts"],
+    "dataSources": ["main.ts", "card.ts", "stripe.ts"],
+    "notes": ["Simula llamadas a API real", "Puede migrarse a JSON externo"]
+  },
+  {
+    "name": "card.ts",
+    "path": "src/services/databaseInMemory/card.ts",
+    "export": "CARD: CardInterface[]",
+    "consumers": ["cardService.ts", "bannerService.ts"],
+    "notes": ["Datos de pruebas para carruseles", "Podría paginarse"]
+  },
+  {
+    "name": "main.ts",
+    "path": "src/services/databaseInMemory/main.ts",
+    "export": "MAIN: MainInterface[]",
+    "consumers": ["bannerService.ts"],
+    "notes": ["Contenido principal para cada página"]
+  },
+  {
+    "name": "stripe.ts",
+    "path": "src/services/databaseInMemory/stripe.ts",
+    "export": "STRIPE: StripeInterface[]",
+    "consumers": ["stripeService.ts", "bannerService.ts"],
+    "notes": ["Tarjetas horizontales con enlace opcional"]
+  }
+]
+```
 
-## banner.ts
-- **Ruta:** `src/services/databaseInMemory/banner.ts`.
-- **Estructura:** exporta `BANNERS`, un `BannerInterface[]` donde cada registro tiene `id` y un arreglo `data`.
-- **Datos relacionados:** `data` se compone de arreglos importados desde `main.ts`, `card.ts` y `stripe.ts` según el `id`.
-- **Uso típico:**
-  ```ts
-  import BannerService from '../services/bannerService';
+Este JSON ofrece los metadatos de cada recurso InMemory. El Code Agent lo utilizará para validar exportaciones e introducir stubs de tests para cada servicio; el Test Agent generará tests de integración simulando respuestas.
 
-  const service = new BannerService();
-  const banners = await service.getAll();
-  ```
-- **Notas:** provee la relación entre banners y sus secciones. Para escalar se podrían cargar estos datos desde una API real o un archivo JSON externo.
+## Criterios de Aceptación
+1. Cada `path` y `export` del JSON existe en el repositorio y coincide con la definición TypeScript.  
+2. Los servicios (`bannerService.ts`, `cardService.ts`, `stripeService.ts`) importan correctamente esos arrays.  
+3. El Test Agent genera tests que simulan llamadas a cada servicio y validan la forma de los objetos (`BannerInterface`, `CardInterface`, etc.).  
+4. Al cambiar cualquier array InMemory, el Doc Agent actualiza este archivo y `src-services-interface.md`.  
+5. La CI incluye un script `npm run test:inmemory` que ejecuta estos tests sin depender de la API real.
 
-## card.ts
-- **Ruta:** `src/services/databaseInMemory/card.ts`.
-- **Estructura:** define `CARD`, un `CardInterface[]` con decenas de objetos que representan tarjetas o beneficios. Incluyen campos opcionales como `image`, `number`, `heading` y `description`.
-- **Uso típico:**
-  ```ts
-  import BannerService from '../services/bannerService';
+[Code Agent]
+"Usa el JSON de src-services-databaseInMemory.md para:
 
-  const list = await new BannerService().getAllById(1);
-  // Acceso a list[0].data que contiene estos elementos
-  ```
-- **Notas:** se utilizan para poblar carruseles y listados de las páginas de servicios. Si creciera el contenido sería conveniente pasar a un formato paginado o separar por ficheros JSON.
+Asegurar que cada fichero exporta el array correspondiente con la interfaz correcta.
 
-## main.ts
-- **Ruta:** `src/services/databaseInMemory/main.ts`.
-- **Estructura:** `MAIN` es un `MainInterface[]` con elementos para el banner principal de cada página. Cada objeto indica `page`, `image`, encabezados y textos introductorios.
-- **Uso típico:**
-  ```ts
-  import BannerService from '../services/bannerService';
+Introducir un método opcional de carga desde un JSON externo y refactorizar los imports.
 
-  const homeBanner = await service.getAllByIdAndPage(0, 'home');
-  ```
-- **Notas:** al ser datos estáticos es sencillo modificar las imágenes o los textos para pruebas A/B. También podrían extraerse a un CMS a futuro.
+Generar un scaffold de un servicio real InMemoryToApiService que pueda reemplazarlo en producción."
 
-## stripe.ts
-- **Ruta:** `src/services/databaseInMemory/stripe.ts`.
-- **Estructura:** contiene `STRIPE`, un `StripeInterface[]` con tarjetas horizontales (imagen, texto y enlace opcional). Algunos registros incluyen `buttonText`, `buttonUrl` y `buttonPathIcon` para construir botones.
-- **Uso típico:**
-  ```ts
-  import BannerService from '../services/bannerService';
+[Test Agent]
+"Genera tests de integración (Jest o Vitest) en __tests__/services/ que:
 
-  const sections = await service.getAllByIdAndPage(2, 'home');
-  ```
-- **Notas:** estas tarjetas complementan el banner principal. Para una aplicación real podrían gestionarse como bloques configurables desde un backend o archivo YAML.
+Mockeen las importaciones InMemory.
 
-En conjunto, estos ficheros proporcionan datos de prueba que permiten desarrollar la interfaz sin depender de un servidor. La modularidad facilita reemplazarlos más adelante por peticiones HTTP o por un sistema de persistencia más robusto.
+Verifiquen que getAll(), getAllById() y getAllByIdAndPage() devuelven datos con las propiedades y tipos esperados."
+
+Enlaces a las interfaces: [BannerInterface](src-services-interface.md#bannerinterfacets), [CardInterface](src-services-interface.md#cardinterfacets), [MainInterface](src-services-interface.md#maininterfacets) y [StripeInterface](src-services-interface.md#stripeinterfacets). Revisa las exportaciones en [`banner.ts`](../src/services/databaseInMemory/banner.ts#L6 "BANNERS") (#BANNERS), [`card.ts`](../src/services/databaseInMemory/card.ts#L3 "CARD") (#CARD), [`main.ts`](../src/services/databaseInMemory/main.ts#L3 "MAIN") (#MAIN) y [`stripe.ts`](../src/services/databaseInMemory/stripe.ts#L3 "STRIPE") (#STRIPE).


### PR DESCRIPTION
## Summary
- provide structured YAML front matter for docs/src-services-databaseInMemory.md
- add machine readable JSON with in-memory data information

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6862c139f8608324861254f9bdb9d06f