### PR TITLE
Update src-styles documentation

### DIFF
--- a/docs/src-styles.md
+++ b/docs/src-styles.md
@@ -1,70 +1,97 @@
-# Estilos en `src/styles/`
+---
+section_id: "SRC-STYLES-12"
+title: "Estilos SCSS"
+version: "1.0"
+date: "2025-07-01"
+related_sections:
+  - "src-assets.md"
+  - "files-and-folders.md"
+  - "STYLEGUIDE.md"
+enforce:
+  - styleguide: "STYLEGUIDE.md"
+  - summary_index: "summary-index.json"
+agents:
+  - Code Agent
+  - Design Agent
+  - Test Agent
+---
 
-Esta carpeta contiene los archivos SCSS de la aplicación. Se divide en un archivo principal, un tema para Bootstrap y varios parciales de componentes.
+Bloque JSON machine-readable
+```json
+[
+  {
+    "file": "src/index.scss",
+    "role": "entry",
+    "imports": ["styles/bootstrap-theme", "styles/index"],
+    "defines": ["@font-face", "base styles", "utilities"],
+    "notes": ["punto de entrada global"]
+  },
+  {
+    "file": "src/styles/bootstrap-theme.scss",
+    "role": "theme",
+    "variables": ["$primary", "$secondary"],
+    "forwards": ["vendor/bootstrap/bootstrap"],
+    "notes": ["personaliza Bootstrap antes de compilar"]
+  },
+  {
+    "file": "src/styles/_index.scss",
+    "role": "aggregator",
+    "imports": [
+      "components/footer",
+      "components/header",
+      "components/content__stripe",
+      "components/main__banner",
+      "components/card__transparent",
+      "components/carousel__collapse",
+      "components/button__top"
+    ],
+    "defines": ["layout classes", "media queries"],
+    "notes": ["agrupa parciales de componentes"]
+  },
+  {
+    "dir": "src/styles/components",
+    "role": "partials",
+    "entries": [
+      "_footer.scss",
+      "_header.scss",
+      "_content__stripe.scss",
+      "_main__banner.scss",
+      "_card__transparent.scss",
+      "_carousel__collapse.scss",
+      "_button__top.scss"
+    ],
+    "notes": ["estilos específicos por componente"]
+  },
+  {
+    "dir": "src/styles/vendor/bootstrap",
+    "role": "bootstrap_vendor",
+    "generated": true,
+    "notes": ["no versionado, creado con bootstrap:migrate"]
+  }
+]
+```
 
-## `src/index.scss`
-- **Propósito:** punto de entrada global importado en `src/main.tsx`.
-- **Importaciones:**
-  - `@forward "./styles/bootstrap-theme";` expone el tema personalizado de Bootstrap.
-  - `@use "./styles/index" as *;` carga reglas comunes y parciales.
-- **Contenido:** define fuentes Montserrat mediante `@font-face`, estilos base para elementos (`html`, `body`, `h1`-`h5`, `.btn`, `.subtitle`, etc.) y clases utilitarias (`.mb-6`, `main { overflow: clip; }`).
+```mermaid
+flowchart TD
+  index.scss --> bootstrap-theme.scss
+  index.scss --> _index.scss
+  _index.scss --> components/_footer.scss
+  _index.scss --> components/_header.scss
+  _index.scss --> components/_...
+```
 
-## `src/styles/bootstrap-theme.scss`
-- **Propósito:** personalizar variables de Bootstrap antes de compilar.
-- **Variables:** establece `$primary` y `$secondary` con los colores de marca.
-- **Estructura:**
-  1. Importa `sass:map` para trabajar con mapas.
-  2. Usa `./vendor/bootstrap/bootstrap` con la configuración anterior (se crea al ejecutar `npm run bootstrap:migrate`).
-  3. Reexporta la librería con `@forward` para que otros módulos puedan usar sus mixins y funciones.
-- **Importación:** se incluye indirectamente desde `src/index.scss` mediante `@forward`.
+[Code Agent]
+"Usa el JSON de src-styles.md para crear un script Node.js que valide la estructura de src/styles/ y que genere un índice de variables SASS (styles/variables.json)."
 
-## `src/styles/_index.scss`
-- **Propósito:** agrupar y distribuir las reglas de estilo de cada sección.
-- **Importa:**
-  - `./components/footer`
-  - `./components/header`
-  - `./components/content__stripe`
-  - `./components/main__banner`
-  - `./components/card__tansparent`
-  - `./components/carusel__collapse`
-  - `./components/button__top`
-- **Contenido:** define clases para páginas y bloques como `.four__industry`, `.our__team`, `.software__services`, `.devices` e `.inner-page`. Incluye media queries para distintos breakpoints.
-- **Uso:** se carga en `src/index.scss` con `@use "./styles/index" as *;` de modo que todas sus clases estén disponibles de forma global.
+[Design Agent]
+"Genera un documento de referencia exportando cada $variable y @mixin definido en los SCSS como un JSON con nombre, valor y archivo de origen."
 
-## Parciales en `src/styles/components/`
-Estos archivos contienen estilos específicos reutilizados por componentes React.
+[Test Agent]
+"Crea tests que validen que el CSS final (tras build) contiene todas las clases listadas en los parciales y no hay clases huérfanas."
 
-### `_footer.scss`
-- **Ruta:** `src/styles/components/_footer.scss`.
-- **Descripción:** estilos del componente `<Footer>`: fondo con `footer-bg.png`, padding general y ajuste responsivo del formulario.
-- **Importación:** incluido desde `_index.scss` y aplicado automáticamente cuando `src/index.scss` se compila.
-
-### `_header.scss`
-- **Ruta:** `src/styles/components/_header.scss`.
-- **Descripción:** reglas para la barra de navegación (`<Header>`), adaptando colores y comportamiento en móviles cuando el menú colapsa.
-
-### `_content__stripe.scss`
-- **Ruta:** `src/styles/components/_content__stripe.scss`.
-- **Descripción:** corrige el orden de la columna de imagen en pantallas pequeñas.
-
-### `_main__banner.scss`
-- **Ruta:** `src/styles/components/_main__banner.scss`.
-- **Descripción:** estilos del carrusel principal con múltiples media queries que ajustan las imágenes de portada y elementos decorativos.
-
-### `_card__tansparent.scss`
-- **Ruta:** `src/styles/components/_card__tansparent.scss`.
-- **Descripción:** apariencia translúcida de las tarjetas con sombras y estilos de botón.
-
-### `_carusel__collapse.scss`
-- **Ruta:** `src/styles/components/_carusel__collapse.scss`.
-- **Descripción:** fondo y formato del carrusel de pasos (`.what__solve`), definiendo tamaños de texto e imagen.
-
-### `_button__top.scss`
-- **Ruta:** `src/styles/components/_button__top.scss`.
-- **Descripción:** clase `.back-to-top` para el botón que vuelve al inicio de la página, ajustando dimensiones del ícono en móviles.
-
-## Organización general
-- `bootstrap-theme.scss` y `components/*` se importan a través de `_index.scss`.
-- `src/index.scss` es el único archivo que se importa explícitamente en la aplicación (`main.tsx`).
-- Al ejecutar `npm run bootstrap:migrate` se genera `src/styles/vendor/bootstrap/` con los SCSS oficiales; este directorio no está versionado pero es requerido para compilar el tema.
-
+## Criterios de Aceptación
+1. El JSON refleja todos los archivos y directorios dentro de `src/styles/`.
+2. Cada ruta existe en disco y su `role` coincide con el uso real.
+3. El Code Agent puede generar un script (`scripts/check-styles.js`) que recorra este JSON y falle si falta algún SCSS.
+4. El Design Agent puede extraer variables y mixins del JSON para generar documentación de estilos automática.
+5. El Test Agent genera tests que comprueben que el bundle CSS final incluye todas las clases definidas en los parciales y que no hay clases huérfanas.


### PR DESCRIPTION
## Summary
- transform `docs/src-styles.md` into a machine-readable format with YAML front matter
- embed JSON structure describing SCSS files
- add mermaid diagram, agent prompts, and acceptance criteria

## Testing
- `npm run lint` *(fails: ESLint couldn't find a valid configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6862c496f87883248de7fa55c492481d