### PR TITLE
Fix unicode escapes in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 section_id: "AGENTS-00"
 title: "Guía de Agentes"
-version: "1.2"
+version: "1.3"
 date: "2025-07-01"
 
 related_sections:
@@ -12,6 +12,7 @@ use_all_sections: true
 enforce:
   - styleguide: "STYLEGUIDE.md"
   - summary_index: "summary-index.json"
+  - unicode_escapes: "docs/*.md"
 agents:
   - Code Agent
   - Doc Agent
@@ -50,6 +51,7 @@ Este archivo define los agentes que colaboran en el mantenimiento y ampliación 
 
 ## Directrices de sincronización
 Si se agrega, elimina o actualiza cualquier archivo o carpeta en el repositorio, se debe actualizar `docs/files-and-folders.md` inmediatamente siguiendo las reglas de `docs/STYLEGUIDE.md` y refrescar el índice en `docs/summary-index.json`.
+Al revisar o actualizar cualquier `docs/*.md`, se debe validar que no existan secuencias `\u00XX`. Si se encuentran, la tarea falla y se debe corregir el archivo.
 
 ## Plantilla de Front Matter YAML
 Se recomienda incluir el siguiente bloque al inicio de cada archivo `docs/*.md` para mantener uniformidad.

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,8 +1,8 @@
 ---
 section_id: "STYLEGUIDE-01"
 title: "Guía de Estilo"
-version: "1.1"
-date: "2025-06-30"
+version: "1.2"
+date: "2025-07-01"
 related_sections:
   - "src-styles.md"
   - "files-and-folders.md"
@@ -117,4 +117,8 @@ El proyecto no define alias de Vite; todas las rutas se importan de forma relati
     }
   ```
 - Para ejecutar el linting se usa `npm run lint` según `package.json`.
+
+## Validación de Codificación Unicode
+
+Todas las secuencias de escape Unicode (`\u00XX`) deben reemplazarse por su carácter UTF-8 correspondiente. Cualquier archivo Markdown que contenga `\u00XX` debe fallar la validación de estilo.
 

--- a/docs/root-and-global-configuration.md
+++ b/docs/root-and-global-configuration.md
@@ -34,31 +34,31 @@ agents:
   {
     "path": "package.json",
     "type": "file",
-    "purpose": "Definici\u00f3n de scripts, dependencias y metadatos del proyecto",
+    "purpose": "Definición de scripts, dependencias y metadatos del proyecto",
     "sections": ["scripts", "dependencies", "devDependencies"]
   },
   {
     "path": "tsconfig.json",
     "type": "file",
-    "purpose": "Opciones de compilaci\u00f3n de TypeScript",
+    "purpose": "Opciones de compilación de TypeScript",
     "sections": ["compilerOptions", "include", "exclude"]
   },
   {
     "path": "vite.config.ts",
     "type": "file",
-    "purpose": "Configuraci\u00f3n de Vite: plugins, servidor y CSS preprocesado",
+    "purpose": "Configuración de Vite: plugins, servidor y CSS preprocesado",
     "sections": ["plugins", "css", "server", "logLevel"]
   }
 ]
 ```
 
-Este JSON describe de forma program\u00e1tica los archivos cr\u00edticos en la ra\u00edz del proyecto, sus roles y las secciones clave que configuran el entorno de desarrollo, build y producci\u00f3n.
+Este JSON describe de forma programática los archivos críticos en la raíz del proyecto, sus roles y las secciones clave que configuran el entorno de desarrollo, build y producción.
 
-Enlaces directos a cada secci\u00f3n: [Dockerfile](#dockerfile), [index.html](#indexhtml), [package.json](#packagejson), [tsconfig.json](#tsconfigjson) y [vite.config.ts](#viteconfigts).
+Enlaces directos a cada sección: [Dockerfile](#dockerfile), [index.html](#indexhtml), [package.json](#packagejson), [tsconfig.json](#tsconfigjson) y [vite.config.ts](#viteconfigts).
 
-# Configuraci\u00f3n Ra\u00edz y Global
+# Configuración Raíz y Global
 
-Este documento detalla los archivos principales en la ra\u00edz de **sowtic-web-page**. Se explica su prop\u00f3sito, configuraci\u00f3n y c\u00f3mo influyen en las tareas de desarrollo, build y producci\u00f3n.
+Este documento detalla los archivos principales en la raíz de **sowtic-web-page**. Se explica su propósito, configuración y cómo influyen en las tareas de desarrollo, build y producción.
 
 ## Dockerfile
 - **Ruta relativa**: `Dockerfile`

--- a/docs/src-hooks.md
+++ b/docs/src-hooks.md
@@ -22,7 +22,7 @@ agents:
     "dependencies": ["react-ga", "react-router-dom"],
     "triggers": ["useEffect", "useLocation"],
     "services": ["Google Analytics (GA4)"],
-    "notes": ["Env\u00eda pageview y evento config gtag"]
+    "notes": ["Envía pageview y evento config gtag"]
   }
 ]
 
@@ -36,9 +36,9 @@ graph LR
 [Code Agent]
 "Lee el JSON anterior y refactoriza usePageTracking.ts para:
 
-Extraer la l\u00f3gica de inicializaci\u00f3n en un hook useGAInit().
+Extraer la lógica de inicialización en un hook useGAInit().
 
-A\u00f1adir manejo de errores si ReactGA.initialize falla.
+Añadir manejo de errores si ReactGA.initialize falla.
 
 Mantener los side-effects bajo useEffect con dependencias [pathname, search]."
 
@@ -51,9 +51,9 @@ Simule cambios de ruta con MemoryRouter.
 
 Verifique que ReactGA.pageview y window.gtag se llamen correctamente."
 
-## Criterios de Aceptaci\u00f3n
+## Criterios de Aceptación
 1. El JSON refleja todos los hooks en `src/hooks/`.
 2. `usePageTracking.ts` existe y exporta el hook con el nombre correcto.
-3. El Code Agent puede generar el refactor solicitado y pasa la compilaci\u00f3n de TypeScript.
+3. El Code Agent puede generar el refactor solicitado y pasa la compilación de TypeScript.
 4. El Test Agent produce un test que cubre ambos flujos de GA y gtag.
-5. El Doc Agent actualiza la documentaci\u00f3n del hook en este archivo tras cualquier cambio.
+5. El Doc Agent actualiza la documentación del hook en este archivo tras cualquier cambio.


### PR DESCRIPTION
## Summary
- correct Unicode escape sequences in root-and-global-configuration.md
- correct Unicode escape sequences in src-hooks.md
- add unicode validation rule in STYLEGUIDE.md
- enforce unicode check in AGENTS.md

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6864194c08bc832499858a4840c4c931