### PR TITLE
Update docs and indexation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Este archivo define los agentes que colaboran en el mantenimiento y ampliación 
 Si se agrega, elimina o actualiza cualquier archivo o carpeta en el repositorio, se debe actualizar `docs/files-and-folders.md` inmediatamente siguiendo las reglas de `docs/STYLEGUIDE.md` y refrescar el índice en `docs/summary-index.json`.
 Al revisar o actualizar cualquier `docs/*.md`, se debe validar que no existan secuencias `\u00XX`. Si se encuentran, la tarea falla y se debe corregir el archivo.
 Si se añade, borra o mueve un documento Markdown dentro de `docs/`, deberá incluirse en `docs/summary-index.json`, llevar Front Matter YAML y registrarse en `docs/files-and-folders.md`.
+Los agentes automatizarán esta indexación para que `summary-index.json` y `files-and-folders.md` reflejen cualquier alta o traslado.
 
 ## Plantilla de Front Matter YAML
 Se recomienda incluir el siguiente bloque al inicio de cada archivo `docs/*.md` para mantener uniformidad.

--- a/docs/components-selectors-mapping.md
+++ b/docs/components-selectors-mapping.md
@@ -12,6 +12,7 @@ enforce:
 agents:
   - Doc Agent
   - Test Agent
+use_all_sections: false
 ---
 
 # Componentes ↔ Selectores CSS

--- a/docs/files-and-folders.md
+++ b/docs/files-and-folders.md
@@ -13,6 +13,7 @@ agents:
   - Code Agent
   - Doc Agent
   - Test Agent
+use_all_sections: false
 ---
 
 # Tabla JSON embebida
@@ -80,7 +81,7 @@ Cuando se agregue, elimine o mueva un documento Markdown en `docs/`, recuerda ta
 - `ButtonToTop.tsx`: botón que aparece al hacer scroll y vuelve al inicio de la página.
 - `CardTransparent.tsx`: tarjeta con estilo transparente; recibe clases para alineación y contenido como children.
 - `ContatUs.tsx`: formulario de contacto que usa EmailJS (`sendForm` con IDs definidos) y un captcha reCAPTCHA.
-- `ScrollToHasElement.ts`: cuando la URL tiene un hash, hace scroll suave al elemento correspondiente.
+- `ScrollToHashElement.ts`: cuando la URL tiene un hash, hace scroll suave al elemento correspondiente.
 - `ScrollToTop.tsx`: envuelve a la aplicación para llevar el scroll al inicio en cada cambio de ruta.
 
 #### src/pages/
@@ -105,7 +106,7 @@ Cuando se agregue, elimine o mueva un documento Markdown en `docs/`, recuerda ta
 - `usePageTracking.ts`: hook que envía la ruta actual a Google Analytics mediante `ReactGA` y `gtag` en cada cambio de navegación.
 
 #### src/utils/
-- `ga.ts`: funciones auxiliares para medir pageviews y eventos con Google Analytics.
+- `ga.ts`: funciones auxiliares para medir pageviews y eventos con Google Analytics. Documentado en `docs/src-utils-ga.md`.
 
 #### router.tsx
 - Define las rutas con `createBrowserRouter` y exporta el componente `<Router>` que envuelve a `RouterProvider`.

--- a/docs/public.md
+++ b/docs/public.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 La carpeta `public/` contiene los recursos servidos sin procesamiento por Vite.
@@ -78,3 +79,7 @@ Lista machine-readable de recursos
   { "path": "public/img/warrning.png", "type": "image", "uses": ["#service-images"] }
 ]
 ```
+
+## Buenas prácticas
+
+Para organizar y servir correctamente la carpeta `public/` se recomienda habilitar mecanismos de cacheo y versionar cada asset con un hash en su nombre. Mueve los recursos que ya no se usen a la subcarpeta `unused/` hasta su eliminación. Favorece formatos modernos como WebP para imágenes y WOFF2 en fuentes. El Test Agent verifica automáticamente estos puntos en la rutina de integración.

--- a/docs/root-and-global-configuration.md
+++ b/docs/root-and-global-configuration.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Doc Agent
   - Test Agent
+use_all_sections: false
 ---
 
 # Tabla JSON embebida

--- a/docs/src-assets.md
+++ b/docs/src-assets.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 # Recursos en `src/assets/`

--- a/docs/src-components-shared.md
+++ b/docs/src-components-shared.md
@@ -14,6 +14,7 @@ agents:
   - Design Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 ``` json
 [

--- a/docs/src-components.md
+++ b/docs/src-components.md
@@ -13,6 +13,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 ```json
 [

--- a/docs/src-hooks.md
+++ b/docs/src-hooks.md
@@ -13,6 +13,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 ```json
 [

--- a/docs/src-pages-layouts.md
+++ b/docs/src-pages-layouts.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 Bloque JSON de definición de layouts

--- a/docs/src-pages.md
+++ b/docs/src-pages.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 ```json

--- a/docs/src-services-databaseInMemory.md
+++ b/docs/src-services-databaseInMemory.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 ```json

--- a/docs/src-services-interface.md
+++ b/docs/src-services-interface.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 ```json
 [

--- a/docs/src-services.md
+++ b/docs/src-services.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 ```json

--- a/docs/src-styles.md
+++ b/docs/src-styles.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Design Agent
   - Test Agent
+use_all_sections: false
 ---
 
 Bloque JSON machine-readable

--- a/docs/src-utils-ga.md
+++ b/docs/src-utils-ga.md
@@ -1,0 +1,38 @@
+---
+section_id: "SRC-UTILS-GA-17"
+title: "Utilidades de Google Analytics"
+version: "1.0"
+date: "2025-07-03"
+related_sections:
+  - "src-hooks.md"
+  - "files-and-folders.md"
+enforce:
+  - styleguide: "STYLEGUIDE.md"
+  - summary_index: "summary-index.json"
+agents:
+  - Code Agent
+  - Test Agent
+  - Doc Agent
+use_all_sections: false
+---
+
+Este documento describe las funciones de apoyo para Google Analytics.
+
+```json
+{
+  "file": "src/utils/ga.ts",
+  "exports": ["pageview", "event"],
+  "dependencies": ["gtag.js", "react-ga"],
+  "examples": [
+    "pageview('/home')",
+    "event({ category: 'User', action: 'Click' })"
+  ]
+}
+```
+
+Las utilidades permiten registrar visitas de página y eventos en GA4 mediante `gtag.js` y la biblioteca `react-ga`. Se invocan desde `usePageTracking` u otros componentes que requieran métricas.
+
+## Criterios de Aceptación
+- El Code Agent genera pruebas que simulan `gtag` para verificar que `pageview` y `event` envían los parámetros correctos.
+- Las funciones exportadas están cubiertas por tests en `src/utils/__tests__/ga.spec.ts`.
+- El Test Agent valida que las llamadas no produzcan errores en navegadores modernos.

--- a/docs/summary-index.json
+++ b/docs/summary-index.json
@@ -78,5 +78,10 @@
     "id": "SUMMARY-16",
     "title": "Mapeo de Selectores UI",
     "file": "ui-selectors.md"
+  },
+  {
+    "id": "SUMMARY-17",
+    "title": "Utilidades de Google Analytics",
+    "file": "src-utils-ga.md"
   }
 ]

--- a/docs/ui-selectors.md
+++ b/docs/ui-selectors.md
@@ -14,6 +14,7 @@ agents:
   - Code Agent
   - Test Agent
   - Doc Agent
+use_all_sections: false
 ---
 
 Bloque JSON machine-readable


### PR DESCRIPTION
## Summary
- fix docs references to ScrollToHashElement and reference new analytics doc
- add `use_all_sections` field to documentation front matters
- expand good practices for the `public/` folder
- document `src/utils/ga.ts`
- update summary index and mention automation in AGENTS

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run check-structure`

------
https://chatgpt.com/codex/tasks/task_e_6865e286cf608324a0f5e734b8284b1f